### PR TITLE
fix: run mail services in foreground mode

### DIFF
--- a/entrypoints/courier-imapd-ssl
+++ b/entrypoints/courier-imapd-ssl
@@ -12,4 +12,4 @@ touch /etc/courier/esmtpaccess
 # Certificates are now mounted directly from cert-manager secrets at /certs/
 # No need to copy or create certificate files - Courier uses them directly
 
-bash -x /usr/lib/courier/sbin/imapd-ssl start
+exec /usr/lib/courier/sbin/imapd-ssl run

--- a/entrypoints/courier-msa
+++ b/entrypoints/courier-msa
@@ -23,5 +23,5 @@ mkdir -p /etc/courier/smtpaccess
 # Certificates are now mounted directly from cert-manager secrets at /certs/
 # No need to copy or create certificate files - Courier uses them directly
 
-# start the msa (courierd runs in separate container)
-/usr/lib/courier/sbin/esmtpd-msa start
+# start the msa in foreground (courierd runs in separate container)
+exec /usr/lib/courier/sbin/esmtpd-msa run

--- a/entrypoints/courier-mta
+++ b/entrypoints/courier-mta
@@ -34,5 +34,5 @@ chmod 750  /var/spool/courier/{msgq,msgs,filters,allfilters}
 chmod 770  /var/spool/courier/tmp
 chmod 755  /var/spool/courier/track
 
-# start the esmtpd (courierd runs in separate container)
-/usr/lib/courier/sbin/esmtpd start
+# start the esmtpd in foreground (courierd runs in separate container)
+exec /usr/lib/courier/sbin/esmtpd run

--- a/entrypoints/courier-mta-ssl
+++ b/entrypoints/courier-mta-ssl
@@ -18,5 +18,5 @@ touch /etc/courier/esmtpaccess
 
 # Certificates are now mounted directly from cert-manager secrets at /certs/
 # No need to copy or create certificate files - Courier uses them directly
-# start the esmtpd-ssl (courierd runs in separate container)
-/usr/lib/courier/sbin/esmtpd-ssl start
+# start the esmtpd-ssl in foreground (courierd runs in separate container)
+exec /usr/lib/courier/sbin/esmtpd-ssl run


### PR DESCRIPTION
- Change from 'start' to 'run' for all courier services
- Use 'exec' to replace shell process with service process
- Prevents containers from backgrounding and exiting
- Services: esmtpd-msa, esmtpd, esmtpd-ssl, imapd-ssl

🤖 Generated with [Claude Code](https://claude.ai/code)