### PR TITLE
fix: use monitoring loop to keep containers alive

### DIFF
--- a/entrypoints/courier-imapd-ssl
+++ b/entrypoints/courier-imapd-ssl
@@ -12,4 +12,14 @@ touch /etc/courier/esmtpaccess
 # Certificates are now mounted directly from cert-manager secrets at /certs/
 # No need to copy or create certificate files - Courier uses them directly
 
-exec /usr/lib/courier/sbin/imapd-ssl run
+# start the imapd-ssl and keep container alive
+/usr/lib/courier/sbin/imapd-ssl start
+
+# Keep container alive by monitoring the service
+while true; do
+    if ! pgrep -f imapd-ssl > /dev/null; then
+        echo "imapd-ssl stopped, restarting..."
+        /usr/lib/courier/sbin/imapd-ssl start
+    fi
+    sleep 10
+done

--- a/entrypoints/courier-msa
+++ b/entrypoints/courier-msa
@@ -23,5 +23,14 @@ mkdir -p /etc/courier/smtpaccess
 # Certificates are now mounted directly from cert-manager secrets at /certs/
 # No need to copy or create certificate files - Courier uses them directly
 
-# start the msa in foreground (courierd runs in separate container)
-exec /usr/lib/courier/sbin/esmtpd-msa run
+# start the msa and keep container alive (courierd runs in separate container)
+/usr/lib/courier/sbin/esmtpd-msa start
+
+# Keep container alive by monitoring the service
+while true; do
+    if ! pgrep -f esmtpd-msa > /dev/null; then
+        echo "esmtpd-msa stopped, restarting..."
+        /usr/lib/courier/sbin/esmtpd-msa start
+    fi
+    sleep 10
+done

--- a/entrypoints/courier-mta
+++ b/entrypoints/courier-mta
@@ -34,5 +34,14 @@ chmod 750  /var/spool/courier/{msgq,msgs,filters,allfilters}
 chmod 770  /var/spool/courier/tmp
 chmod 755  /var/spool/courier/track
 
-# start the esmtpd in foreground (courierd runs in separate container)
-exec /usr/lib/courier/sbin/esmtpd run
+# start the esmtpd and keep container alive (courierd runs in separate container)
+/usr/lib/courier/sbin/esmtpd start
+
+# Keep container alive by monitoring the service
+while true; do
+    if ! pgrep -f esmtpd > /dev/null; then
+        echo "esmtpd stopped, restarting..."
+        /usr/lib/courier/sbin/esmtpd start
+    fi
+    sleep 10
+done

--- a/entrypoints/courier-mta-ssl
+++ b/entrypoints/courier-mta-ssl
@@ -18,5 +18,14 @@ touch /etc/courier/esmtpaccess
 
 # Certificates are now mounted directly from cert-manager secrets at /certs/
 # No need to copy or create certificate files - Courier uses them directly
-# start the esmtpd-ssl in foreground (courierd runs in separate container)
-exec /usr/lib/courier/sbin/esmtpd-ssl run
+# start the esmtpd-ssl and keep container alive (courierd runs in separate container)
+/usr/lib/courier/sbin/esmtpd-ssl start
+
+# Keep container alive by monitoring the service
+while true; do
+    if ! pgrep -f esmtpd-ssl > /dev/null; then
+        echo "esmtpd-ssl stopped, restarting..."
+        /usr/lib/courier/sbin/esmtpd-ssl start
+    fi
+    sleep 10
+done


### PR DESCRIPTION
- Start courier services with 'start' command (backgrounds properly)
- Add monitoring loop to check service health every 10 seconds
- Restart services automatically if they stop
- Keeps containers running without forcing foreground mode
- Services: esmtpd-msa, esmtpd, esmtpd-ssl, imapd-ssl

🤖 Generated with [Claude Code](https://claude.ai/code)