### PR TITLE
fix: resolve MTA aliases and IMAP user issues

### DIFF
--- a/deployment/k8s/courier-imapd-ssl.yaml
+++ b/deployment/k8s/courier-imapd-ssl.yaml
@@ -27,7 +27,7 @@ spec:
         - |
           mkdir -p /etc/authlib/userdb
           chmod 700 /etc/authlib/userdb
-          chown -R vmail:vmail /etc/authlib
+          chown -R 300:300 /etc/authlib
         volumeMounts:
         - name: courier-auth
           mountPath: /etc/authlib

--- a/entrypoints/courier-mta
+++ b/entrypoints/courier-mta
@@ -18,6 +18,8 @@ touch /etc/courier/esmtpaccess
       chown -R $THEUSER userdb )
   
 /usr/sbin/makeuserdb
+# Create empty aliases file if it doesn't exist
+touch /etc/courier/aliases
 /usr/lib/courier/sbin/makealiases
 
 /usr/sbin/authdaemond start


### PR DESCRIPTION
- Create empty aliases file for MTA service before makealiases
- Use numeric UID:GID (300:300) instead of vmail:vmail in IMAP init
- Fixes missing /etc/courier/aliases error in MTA
- Fixes unknown user/group error in IMAP init container

🤖 Generated with [Claude Code](https://claude.ai/code)