### PR TITLE
fix: remove unnecessary SMTP access files from IMAP service

### DIFF
--- a/entrypoints/courier-imapd-ssl
+++ b/entrypoints/courier-imapd-ssl
@@ -2,9 +2,7 @@
 
 set -e -x -o pipefail
 
-# Create empty esmtpaccess file if it doesn't exist
-touch /etc/courier/esmtpaccess
-/usr/lib/courier/sbin/makesmtpaccess
+# IMAP service doesn't need SMTP access control files
 /usr/sbin/makeuserdb
 
 /usr/sbin/authdaemond start


### PR DESCRIPTION
- Remove esmtpaccess file creation from IMAP entrypoint
- IMAP service doesn't need SMTP access control
- Fixes permission denied error when IMAP (UID 300) tries to write to courier config
- SMTP services handle their own access control files

🤖 Generated with [Claude Code](https://claude.ai/code)