### PR TITLE
fix: add imagePullPolicy Always to all mail services

### DIFF
--- a/deployment/k8s/courier-imapd-ssl.yaml
+++ b/deployment/k8s/courier-imapd-ssl.yaml
@@ -36,6 +36,7 @@ spec:
       containers:
       - name: courier-imapd-ssl
         image: ghcr.io/pcn/mailbag/courier-imapd-ssl:main
+        imagePullPolicy: Always
         ports:
         - containerPort: 993
           name: imaps

--- a/deployment/k8s/courier-mta-ssl.yaml
+++ b/deployment/k8s/courier-mta-ssl.yaml
@@ -40,6 +40,7 @@ spec:
       containers:
       - name: courier-mta-ssl
         image: ghcr.io/pcn/mailbag/courier-mta-ssl:main
+        imagePullPolicy: Always
         ports:
         - containerPort: 465
           name: smtps

--- a/deployment/k8s/courier-mta.yaml
+++ b/deployment/k8s/courier-mta.yaml
@@ -40,6 +40,7 @@ spec:
       containers:
       - name: courier-mta
         image: ghcr.io/pcn/mailbag/courier-mta:main
+        imagePullPolicy: Always
         ports:
         - containerPort: 25
           name: smtp


### PR DESCRIPTION
- Add imagePullPolicy: Always to MTA, MTA-SSL, and IMAP-SSL services
- Ensures Kubernetes pulls latest container images on pod restart
- MSA already had this setting, now all services consistent
- Required for getting latest entrypoint fixes

🤖 Generated with [Claude Code](https://claude.ai/code)