### PR TITLE
fix: create missing directories and files for MTA and IMAP

### DIFF
--- a/entrypoints/courier-imapd-ssl
+++ b/entrypoints/courier-imapd-ssl
@@ -3,6 +3,8 @@
 set -e -x -o pipefail
 
 # IMAP service doesn't need SMTP access control files
+# Create empty userdb file if it doesn't exist
+touch /etc/authlib/userdb
 /usr/sbin/makeuserdb
 
 /usr/sbin/authdaemond start

--- a/entrypoints/courier-mta
+++ b/entrypoints/courier-mta
@@ -18,7 +18,8 @@ touch /etc/courier/esmtpaccess
       chown -R $THEUSER userdb )
   
 /usr/sbin/makeuserdb
-# Create empty aliases file if it doesn't exist
+# Create empty aliases file and directory if they don't exist
+mkdir -p /etc/courier/aliasdir
 touch /etc/courier/aliases
 /usr/lib/courier/sbin/makealiases
 


### PR DESCRIPTION
- Create aliasdir directory before running makealiases in MTA
- Create empty userdb file before running makeuserdb in IMAP
- Fixes mkdir and file not found errors preventing service startup
- Required for proper courier mail system initialization

🤖 Generated with [Claude Code](https://claude.ai/code)