### PR TITLE
fix: resolve IMAP userdb and MTA-SSL template issues

### DIFF
--- a/deployment/k8s/courier-imapd-ssl.yaml
+++ b/deployment/k8s/courier-imapd-ssl.yaml
@@ -26,6 +26,7 @@ spec:
         - -c
         - |
           mkdir -p /etc/authlib/userdb
+          touch /etc/authlib/userdb
           chmod 700 /etc/authlib/userdb
           chown -R 300:300 /etc/authlib
         volumeMounts:

--- a/deployment/k8s/courier-mta-ssl.yaml
+++ b/deployment/k8s/courier-mta-ssl.yaml
@@ -65,6 +65,12 @@ spec:
         - name: templates
           mountPath: /hosteddomains.template
           subPath: hosteddomains.template
+        - name: templates
+          mountPath: /esmtpd-base-mta-ssl.template
+          subPath: esmtpd-base-mta-ssl.template
+        - name: templates
+          mountPath: /esmtpd-mta-ssl.template
+          subPath: esmtpd-mta-ssl.template
         securityContext:
           runAsUser: 1
           runAsGroup: 1

--- a/entrypoints/courier-imapd-ssl
+++ b/entrypoints/courier-imapd-ssl
@@ -2,9 +2,8 @@
 
 set -e -x -o pipefail
 
-# IMAP service doesn't need SMTP access control files
-# Create empty userdb file if it doesn't exist
-touch /etc/authlib/userdb
+# IMAP service doesn't need SMTP access control files  
+# userdb file should be created by init container as root
 /usr/sbin/makeuserdb
 
 /usr/sbin/authdaemond start

--- a/entrypoints/courier-mta-ssl
+++ b/entrypoints/courier-mta-ssl
@@ -5,6 +5,8 @@ set -e -x -o pipefail
 # context.json is added via the docker/container as a bind mount
 /render-template --context /context.json --template /acceptmailfor.template > /etc/courier/esmtpacceptmailfor.dir/context
 /render-template --context /context.json --template /hosteddomains.template > /etc/courier/hosteddomains
+/render-template --context /context.json --template /esmtpd-base-mta-ssl.template > /etc/courier/esmtpd
+/render-template --context /context.json --template /esmtpd-mta-ssl.template > /etc/courier/esmtpd-ssl
 
 /usr/lib/courier/share/makeacceptmailfor
 /usr/lib/courier/share/makehosteddomains


### PR DESCRIPTION
- Create userdb file in IMAP init container as root to avoid permission errors
- Add missing esmtpd-ssl template rendering to MTA-SSL entrypoint
- Add esmtpd-base-mta-ssl and esmtpd-mta-ssl template mounts to MTA-SSL deployment
- Fixes IMAP permission denied and MTA-SSL missing config file errors

🤖 Generated with [Claude Code](https://claude.ai/code)