### PR TITLE
fix: resolve makesmtpaccess and IMAP userdb directory issues

### DIFF
--- a/deployment/k8s/courier-imapd-ssl.yaml
+++ b/deployment/k8s/courier-imapd-ssl.yaml
@@ -26,7 +26,7 @@ spec:
         - -c
         - |
           mkdir -p /etc/authlib/userdb
-          touch /etc/authlib/userdb
+          touch /etc/authlib/userdb/dummy
           chmod 700 /etc/authlib/userdb
           chown -R 300:300 /etc/authlib
         volumeMounts:

--- a/entrypoints/courier-mta
+++ b/entrypoints/courier-mta
@@ -12,7 +12,8 @@ export THEUSER=daemon
 /usr/lib/courier/share/makehosteddomains
 # Create empty esmtpaccess file if it doesn't exist
 touch /etc/courier/esmtpaccess
-/usr/lib/courier/sbin/makesmtpaccess
+# Skip makesmtpaccess if esmtpaccess is empty  
+[ -s /etc/courier/esmtpaccess ] && /usr/lib/courier/sbin/makesmtpaccess || echo "Empty esmtpaccess file, skipping makesmtpaccess"
 ( cd /etc/authlib && \
       chmod -R 700 userdb && \
       chown -R $THEUSER userdb )

--- a/entrypoints/courier-mta-ssl
+++ b/entrypoints/courier-mta-ssl
@@ -12,7 +12,8 @@ set -e -x -o pipefail
 /usr/lib/courier/share/makehosteddomains
 # Create empty esmtpaccess file if it doesn't exist
 touch /etc/courier/esmtpaccess
-/usr/lib/courier/sbin/makesmtpaccess
+# Skip makesmtpaccess if esmtpaccess is empty
+[ -s /etc/courier/esmtpaccess ] && /usr/lib/courier/sbin/makesmtpaccess || echo "Empty esmtpaccess file, skipping makesmtpaccess"
 /usr/sbin/makeuserdb
 /usr/lib/courier/sbin/makealiases
 


### PR DESCRIPTION
- Skip makesmtpaccess when esmtpaccess file is empty to avoid usage errors
- Create dummy file in userdb directory instead of creating userdb as file
- Fixes MTA/MTA-SSL makesmtpaccess usage errors and IMAP userdb not found
- Services can now start without courier access control configuration

🤖 Generated with [Claude Code](https://claude.ai/code)