### PR TITLE
fix: skip makeuserdb when no test users configured

### DIFF
--- a/entrypoints/courier-imapd-ssl
+++ b/entrypoints/courier-imapd-ssl
@@ -3,8 +3,12 @@
 set -e -x -o pipefail
 
 # IMAP service doesn't need SMTP access control files  
-# userdb file should be created by init container as root
-/usr/sbin/makeuserdb
+# Skip makeuserdb if userdb directory is empty (no test users configured yet)
+if [ "$(ls -A /etc/authlib/userdb 2>/dev/null)" ]; then
+    /usr/sbin/makeuserdb
+else
+    echo "Empty userdb directory, skipping makeuserdb (no test users configured)"
+fi
 
 /usr/sbin/authdaemond start
 


### PR DESCRIPTION
- Skip makeuserdb if userdb directory is empty to avoid startup errors
- Add clear message that no test users are configured yet
- Allows IMAP service to start for testing infrastructure
- makeuserdb can be re-enabled later when test users are added

🤖 Generated with [Claude Code](https://claude.ai/code)