### PR TITLE
fix: create combined certificate file for MTA-SSL using init container

### DIFF
--- a/deployment/k8s/configmap.yaml
+++ b/deployment/k8s/configmap.yaml
@@ -317,9 +317,8 @@ data:
     MAXDAEMONS={{ mta.max_daemons | default("40") }}
     MAXPERIP={{ mta.max_per_ip | default("4") }}
 
-    # TLS certificate files
-    TLS_CERTFILE={{ mta.tls_certfile }}
-    TLS_PRIVATE_KEYFILE={{ mta.tls_keyfile }}
+    # TLS certificate files (use combined file approach like IMAP-SSL)
+    TLS_CERTFILE=/usr/lib/courier/share/esmtpd.pem
 
     # Courier TLS binary location
     COURIERTLS=/usr/lib/courier/bin/couriertls
@@ -359,9 +358,8 @@ data:
     MAXDAEMONS={{ mta_ssl.max_daemons | default("40") }}
     MAXPERIP={{ mta_ssl.max_per_ip | default("4") }}
 
-    # TLS certificate files
-    TLS_CERTFILE={{ mta_ssl.tls_certfile }}
-    TLS_PRIVATE_KEYFILE={{ mta_ssl.tls_keyfile }}
+    # TLS certificate files (use combined file approach like IMAP-SSL)
+    TLS_CERTFILE=/usr/lib/courier/share/esmtpd.pem
 
     # Courier TLS binary location
     COURIERTLS=/usr/lib/courier/bin/couriertls

--- a/deployment/k8s/courier-mta-ssl.yaml
+++ b/deployment/k8s/courier-mta-ssl.yaml
@@ -30,11 +30,21 @@ spec:
           chmod 700 /etc/authlib/userdb
           chown -R daemon:daemon /etc/courier
           chown -R daemon:daemon /etc/authlib
+          # Create combined certificate file for Courier SSL
+          mkdir -p /courier-share
+          cat /certs/tls.crt /certs/tls.key > /courier-share/esmtpd.pem
+          chmod 600 /courier-share/esmtpd.pem
+          chown daemon:daemon /courier-share/esmtpd.pem
         volumeMounts:
         - name: courier-config
           mountPath: /etc/courier
         - name: courier-auth
           mountPath: /etc/authlib
+        - name: courier-cert
+          mountPath: /certs
+          readOnly: true
+        - name: courier-share
+          mountPath: /courier-share
         securityContext:
           runAsUser: 0
       containers:
@@ -56,6 +66,8 @@ spec:
         - name: courier-cert
           mountPath: /certs
           readOnly: true
+        - name: courier-share
+          mountPath: /usr/lib/courier/share
         - name: context-json
           mountPath: /context.json
           readOnly: true
@@ -93,6 +105,8 @@ spec:
       - name: courier-cert
         secret:
           secretName: courier-mta-cert-tls
+      - name: courier-share
+        emptyDir: {}
       - name: context-json
         hostPath:
           path: /etc/mailbag/context.json


### PR DESCRIPTION
- Init container creates combined cert+key file in shared volume
- Main container mounts the shared volume at /usr/lib/courier/share/
- Configuration uses combined TLS_CERTFILE=/usr/lib/courier/share/esmtpd.pem
- This matches the pattern that IMAP-SSL uses successfully
- Fixes segmentation fault in couriertcpd SSL initialization

🤖 Generated with [Claude Code](https://claude.ai/code)