### PR TITLE
fix: mount shared certificate volume at /shared-certs to avoid hiding…

### DIFF
--- a/deployment/k8s/courier-mta-ssl.yaml
+++ b/deployment/k8s/courier-mta-ssl.yaml
@@ -31,10 +31,10 @@ spec:
           chown -R daemon:daemon /etc/courier
           chown -R daemon:daemon /etc/authlib
           # Create combined certificate file for Courier SSL
-          mkdir -p /courier-share
-          cat /certs/tls.crt /certs/tls.key > /courier-share/esmtpd.pem
-          chmod 600 /courier-share/esmtpd.pem
-          chown daemon:daemon /courier-share/esmtpd.pem
+          mkdir -p /shared-certs
+          cat /certs/tls.crt /certs/tls.key > /shared-certs/esmtpd.pem
+          chmod 600 /shared-certs/esmtpd.pem
+          chown daemon:daemon /shared-certs/esmtpd.pem
         volumeMounts:
         - name: courier-config
           mountPath: /etc/courier
@@ -44,7 +44,7 @@ spec:
           mountPath: /certs
           readOnly: true
         - name: courier-share
-          mountPath: /courier-share
+          mountPath: /shared-certs
         securityContext:
           runAsUser: 0
       containers:
@@ -67,7 +67,7 @@ spec:
           mountPath: /certs
           readOnly: true
         - name: courier-share
-          mountPath: /usr/lib/courier/share
+          mountPath: /shared-certs
         - name: context-json
           mountPath: /context.json
           readOnly: true

--- a/entrypoints/courier-mta-ssl
+++ b/entrypoints/courier-mta-ssl
@@ -27,8 +27,9 @@ fi
 
 /usr/sbin/authdaemond start
 
-# Certificates are now mounted directly from cert-manager secrets at /certs/
-# No need to copy or create certificate files - Courier uses them directly
+# Copy combined certificate file from shared volume to courier directory
+cp /shared-certs/esmtpd.pem /usr/lib/courier/share/esmtpd.pem
+
 # start the esmtpd-ssl and keep container alive (courierd runs in separate container)
 /usr/lib/courier/sbin/esmtpd-ssl start
 


### PR DESCRIPTION
… courier utilities

- Changed volume mount from /usr/lib/courier/share/ to /shared-certs
- Added certificate copy in entrypoint: cp /shared-certs/esmtpd.pem /usr/lib/courier/share/
- This preserves access to makeacceptmailfor and other courier utilities
- Combined certificate still available where Courier expects it

🤖 Generated with [Claude Code](https://claude.ai/code)