### PR TITLE
fix: point TLS_CERTFILE directly to /shared-certs/esmtpd.pem

### DIFF
--- a/deployment/k8s/configmap.yaml
+++ b/deployment/k8s/configmap.yaml
@@ -318,7 +318,7 @@ data:
     MAXPERIP={{ mta.max_per_ip | default("4") }}
 
     # TLS certificate files (use combined file approach like IMAP-SSL)
-    TLS_CERTFILE=/usr/lib/courier/share/esmtpd.pem
+    TLS_CERTFILE=/shared-certs/esmtpd.pem
 
     # Courier TLS binary location
     COURIERTLS=/usr/lib/courier/bin/couriertls
@@ -359,7 +359,7 @@ data:
     MAXPERIP={{ mta_ssl.max_per_ip | default("4") }}
 
     # TLS certificate files (use combined file approach like IMAP-SSL)
-    TLS_CERTFILE=/usr/lib/courier/share/esmtpd.pem
+    TLS_CERTFILE=/shared-certs/esmtpd.pem
 
     # Courier TLS binary location
     COURIERTLS=/usr/lib/courier/bin/couriertls

--- a/entrypoints/courier-mta-ssl
+++ b/entrypoints/courier-mta-ssl
@@ -27,9 +27,8 @@ fi
 
 /usr/sbin/authdaemond start
 
-# Copy combined certificate file from shared volume to courier directory
-cp /shared-certs/esmtpd.pem /usr/lib/courier/share/esmtpd.pem
-
+# Combined certificate file created by init container at /shared-certs/esmtpd.pem
+# Configuration points directly to this location
 # start the esmtpd-ssl and keep container alive (courierd runs in separate container)
 /usr/lib/courier/sbin/esmtpd-ssl start
 


### PR DESCRIPTION
- Removed unnecessary copy operation that would fail due to permissions
- Configuration now uses TLS_CERTFILE=/shared-certs/esmtpd.pem directly
- Init container creates the combined cert, main container references it
- Avoids permission issues with daemon user trying to write to /usr/lib/

🤖 Generated with [Claude Code](https://claude.ai/code)