### PR TITLE
fix: generate proper esmtpaccess file for couriertcpd

### DIFF
--- a/deployment/k8s/courier-mta-ssl.yaml
+++ b/deployment/k8s/courier-mta-ssl.yaml
@@ -38,6 +38,13 @@ spec:
           # Also copy to legacy location for compatibility
           mkdir -p /usr/lib/courier/share
           cp /shared-certs/esmtpd.pem /usr/lib/courier/share/esmtpd.pem
+          # Create minimal esmtpaccess file for MTA-SSL
+          cat > /etc/courier/esmtpaccess << 'EOF'
+          # Default access policies for MTA-SSL
+          # Allow connections (no relaying restrictions for incoming mail)
+          0.0.0.0/0	allow
+          ::/0		allow
+          EOF
         volumeMounts:
         - name: courier-config
           mountPath: /etc/courier

--- a/entrypoints/courier-mta-ssl
+++ b/entrypoints/courier-mta-ssl
@@ -13,10 +13,8 @@ set -e -x -o pipefail
 
 /usr/lib/courier/share/makeacceptmailfor
 /usr/lib/courier/share/makehosteddomains
-# Create empty esmtpaccess file if it doesn't exist
-touch /etc/courier/esmtpaccess
-# Skip makesmtpaccess if esmtpaccess is empty
-[ -s /etc/courier/esmtpaccess ] && /usr/lib/courier/sbin/makesmtpaccess || echo "Empty esmtpaccess file, skipping makesmtpaccess"
+# Process esmtpaccess file (created by init container)
+/usr/lib/courier/sbin/makesmtpaccess
 # Skip makeuserdb if userdb directory is empty (no test users configured yet)
 if [ "$(ls -A /etc/authlib/userdb 2>/dev/null)" ]; then
     /usr/sbin/makeuserdb


### PR DESCRIPTION
- Create minimal esmtpaccess file in init container with basic access rules
- Always run makesmtpaccess in main container to process access database
- Fixes potential segfault from missing/invalid ACCESSFILE parameter

🤖 Generated with [Claude Code](https://claude.ai/code)